### PR TITLE
Add spaCy 3 version of ch2/lemmatization2.py

### DIFF
--- a/ch2/index.txt
+++ b/ch2/index.txt
@@ -1,6 +1,7 @@
 tokenization.py - p18
 lemmatization.py - p18
-lemmatization2.py - p20
+lemmatization2.py - p20 (for spaCy 2.x)
+lemmatization2b.py - p20 (for spaCy 3.x)
 pos.py - p23
 dependency.py - p26
 dependency2.py - p28

--- a/ch2/lemmatization2.py
+++ b/ch2/lemmatization2.py
@@ -1,3 +1,4 @@
+# For spaCy 2.x
 import spacy
 from spacy.symbols import ORTH, LEMMA
 nlp = spacy.load('en')

--- a/ch2/lemmatization2b.py
+++ b/ch2/lemmatization2b.py
@@ -1,0 +1,9 @@
+# For spaCy 3.x
+# See https://github.com/nlptechbook/examples/issues/5
+import spacy
+from spacy.symbols import LEMMA
+nlp = spacy.load('en')
+doc = nlp(u'I am flying to Frisco')
+print([w.text for w in doc])
+nlp.get_pipe("attribute_ruler").add([[{"TEXT": "Frisco"}]], {"LEMMA": "San Francisco"})
+print([w.lemma_ for w in nlp(u'I am flying to Frisco')])


### PR DESCRIPTION
This pull request proposes adding a second version of **ch2/lemmatization2.py**, to acknowledge a behavior change between spaCy 2 and 3 that breaks the example in the book.

Closes https://github.com/nlptechbook/examples/issues/5